### PR TITLE
DASD-15638 - Allow egress to api.education.gov.uk

### DIFF
--- a/config/CDS-FwRules/firewall_rules_at.json
+++ b/config/CDS-FwRules/firewall_rules_at.json
@@ -1597,7 +1597,13 @@
             "*.core.windows.net",
             "*.vault.azure.net",
             "*.zendesk.com",
-            "management.azure.com"
+            "management.azure.com",
+            "api.appstoreconnect.apple.com",
+            "oauth2.googleapis.com",
+            "www.googleapis.com",
+            "androidpublisher.googleapis.com",
+            "playdeveloperreporting.googleapis.com",
+            "storage.googleapis.com"
           ],
           "fqdnTags": [],
           "httpHeadersToInsert": [],

--- a/config/CDS-FwRules/firewall_rules_at.json
+++ b/config/CDS-FwRules/firewall_rules_at.json
@@ -1593,6 +1593,7 @@
             "login.windows.net",
             "*.azurewebsites.net",
             "*.apprenticeships.education.gov.uk",
+            "api.education.gov.uk",
             "*.core.windows.net",
             "*.vault.azure.net",
             "*.zendesk.com",

--- a/config/CDS-FwRules/firewall_rules_demo.json
+++ b/config/CDS-FwRules/firewall_rules_demo.json
@@ -1398,6 +1398,7 @@
             "login.windows.net",
             "*.azurewebsites.net",
             "*.apprenticeships.education.gov.uk",
+            "api.education.gov.uk",
             "*.core.windows.net",
             "*.vault.azure.net",
             "*.zendesk.com",

--- a/config/CDS-FwRules/firewall_rules_demo.json
+++ b/config/CDS-FwRules/firewall_rules_demo.json
@@ -1405,7 +1405,13 @@
             "management.azure.com",
             "*.platform.education.gov.uk",
             "*.apprenticeships.education.gov.uk",
-            "dev-api-customerengagement.platform.education.gov.uk"
+            "dev-api-customerengagement.platform.education.gov.uk",
+            "api.appstoreconnect.apple.com",
+            "oauth2.googleapis.com",
+            "www.googleapis.com",
+            "androidpublisher.googleapis.com",
+            "playdeveloperreporting.googleapis.com",
+            "storage.googleapis.com"
           ],
           "fqdnTags": [],
           "httpHeadersToInsert": [],

--- a/config/CDS-FwRules/firewall_rules_test.json
+++ b/config/CDS-FwRules/firewall_rules_test.json
@@ -1574,6 +1574,7 @@
             "login.windows.net",
             "*.azurewebsites.net",
             "*.apprenticeships.education.gov.uk",
+            "api.education.gov.uk",
             "*.core.windows.net",
             "*.vault.azure.net",
             "*.zendesk.com",

--- a/config/CDS-FwRules/firewall_rules_test.json
+++ b/config/CDS-FwRules/firewall_rules_test.json
@@ -1581,7 +1581,13 @@
             "management.azure.com",
             "*.platform.education.gov.uk",
             "*.apprenticeships.education.gov.uk",
-            "dev-api-customerengagement.platform.education.gov.uk"
+            "dev-api-customerengagement.platform.education.gov.uk",
+            "api.appstoreconnect.apple.com",
+            "oauth2.googleapis.com",
+            "www.googleapis.com",
+            "androidpublisher.googleapis.com",
+            "playdeveloperreporting.googleapis.com",
+            "storage.googleapis.com"
           ],
           "fqdnTags": [],
           "httpHeadersToInsert": [],

--- a/config/CDS-FwRules/firewall_rules_test2.json
+++ b/config/CDS-FwRules/firewall_rules_test2.json
@@ -1398,6 +1398,7 @@
             "login.windows.net",
             "*.azurewebsites.net",
             "*.apprenticeships.education.gov.uk",
+            "api.education.gov.uk",
             "*.core.windows.net",
             "*.vault.azure.net",
             "*.zendesk.com",

--- a/config/CDS-FwRules/firewall_rules_test2.json
+++ b/config/CDS-FwRules/firewall_rules_test2.json
@@ -1405,7 +1405,13 @@
             "management.azure.com",
             "*.platform.education.gov.uk",
             "*.apprenticeships.education.gov.uk",
-            "dev-api-customerengagement.platform.education.gov.uk"
+            "dev-api-customerengagement.platform.education.gov.uk",
+            "api.appstoreconnect.apple.com",
+            "oauth2.googleapis.com",
+            "www.googleapis.com",
+            "androidpublisher.googleapis.com",
+            "playdeveloperreporting.googleapis.com",
+            "storage.googleapis.com"
           ],
           "fqdnTags": [],
           "httpHeadersToInsert": [],

--- a/config/FCS-FwRules/firewall_rules_pp.json
+++ b/config/FCS-FwRules/firewall_rules_pp.json
@@ -1950,7 +1950,13 @@
             "management.azure.com",
             "*.platform.education.gov.uk",
             "*.apprenticeships.education.gov.uk",
-            "dev-api-customerengagement.platform.education.gov.uk"
+            "dev-api-customerengagement.platform.education.gov.uk",
+            "api.appstoreconnect.apple.com",
+            "oauth2.googleapis.com",
+            "www.googleapis.com",
+            "androidpublisher.googleapis.com",
+            "playdeveloperreporting.googleapis.com",
+            "storage.googleapis.com"
           ],
           "fqdnTags": [],
           "httpHeadersToInsert": [],

--- a/config/FCS-FwRules/firewall_rules_pp.json
+++ b/config/FCS-FwRules/firewall_rules_pp.json
@@ -1943,6 +1943,7 @@
             "login.windows.net",
             "*.azurewebsites.net",
             "*.apprenticeships.education.gov.uk",
+            "api.education.gov.uk",
             "*.core.windows.net",
             "*.vault.azure.net",
             "*.zendesk.com",

--- a/config/hub.template.json
+++ b/config/hub.template.json
@@ -366,7 +366,7 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2021-04-01",
       "name": "ApplicationRuleCollectionDeployment",
-      "dependsOn": [ "FirewallPoliciesDeployment" ],
+      "dependsOn": [ "dnatRuleCollectionGroupName" ],
       "properties": {
         "mode": "Incremental",
         "templateLink": {

--- a/config/hub.template.json
+++ b/config/hub.template.json
@@ -366,7 +366,7 @@
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2021-04-01",
       "name": "ApplicationRuleCollectionDeployment",
-      "dependsOn": [ "dnatRuleCollectionGroupName" ],
+      "dependsOn": [ "FirewallPoliciesDeployment" ],
       "properties": {
         "mode": "Incremental",
         "templateLink": {


### PR DESCRIPTION
The Vacancy AI API calls the LLM endpoint at https://api.education.gov.uk. All outbound internet traffic from the app services is forced through the hub firewall (VNet integration with Route All enabled), and no application rule permitted this FQDN, so the firewall denied it by default:

  HTTPS request from 10.1.44.252:51034 to api.education.gov.uk:443.
  Action: Deny. No rule matched. Proceeding with default action.

Azure Firewall filters HTTPS by SNI, completing the TCP handshake before dropping, so the caller sees a TLS handshake failure rather than a refused connection. This surfaced as an apparent SSL error in the AI API.

The existing *.apprenticeships.education.gov.uk entry does not cover api.education.gov.uk, so an explicit FQDN is required.

Added to the Allow-AppServices-Endpoints collection for at, test, test2 and demo. PP is unchanged in this commit. PROD and MO firewall rules are not managed in this repo.